### PR TITLE
Fix crash with shared collision_mask table references

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.1.9
+Date: ???
+  Bugfixes:
+    - Fixed crash when the prototype and the next_upgrade collision_mask are the same table reference
+      e.g. when a mod does `prototypeA.collision_mask = prototypeB.collision_mask`
+---------------------------------------------------------------------------------------------------
 Version: 1.1.8
 Date: 2024-3-14
   Minor Features:

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -347,7 +347,7 @@ for group, _ in pairs(ownableEntities) do
 			-- only change prototypes that aren't excluded via easy-mode or initial list
 			if prototype and not alteredPrototypes[prototype.name] then
 				-- ignore nonexistent prototypes and ones that have already been fixed
-				prototype.collision_mask = maskUtil.get_mask(prototype)
+				prototype.collision_mask = table.deepcopy(maskUtil.get_mask(prototype))
 				alteredPrototypes[prototype.name] = true
 				if maskUtil.mask_contains_layer(prototype.collision_mask, "object-layer") then
 					-- check the mask is supposed to collide with objects

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "zzz-claustorephobic",
-	"version": "1.1.8",
+	"version": "1.1.9",
 	"title": "ClaustOrephobic",
 	"author": "Braxbro",
 	"factorio_version": "1.1",


### PR DESCRIPTION
e.g. when a mod does `prototypeA.collision_mask = prototypeB.collision_mask`

numal-reef-mk01 and numal-reef-mk02 have the same collision mask table (the same reference, i.e. they both use the same table in memory), so when one was modified, the next_upgrade would fail this check, making `upgrade` nil and crashing the script when it tries to log `upgrade.name` https://github.com/Braxbro/zzz-claustorephobic/blob/206832bcd3cea5831b151c55e2b587701fea5120/data-final-fixes.lua#L360

This fixes a crash with Pyanodons Alternative Energy